### PR TITLE
Update version and enable NuGet symbol package generation

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Authors>Maytham Fahmi and Contributors</Authors>
     <Copyright>All Rights Reserved</Copyright>
-    <Version>3.3.0</Version>
-    <FileVersion>3.4.0.0</FileVersion>
-    <AssemblyVersion>3.4.0.0</AssemblyVersion>
+    <Version>3.4.1</Version>
+    <FileVersion>3.4.1.0</FileVersion>
+    <AssemblyVersion>3.4.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,6 +19,10 @@
 
     <!-- Some of us are already working with the next SDK -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+
+    <!-- Generate symbol packages for NuGet -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Updated versioning in `Directory.Build.Props` to `3.4.1` for `<Version>`, `<FileVersion>`, and `<AssemblyVersion>`.

Added properties to generate NuGet symbol packages:
- Enabled `<IncludeSymbols>` with value `true`.
- Set `<SymbolPackageFormat>` to `snupkg`.

Retained existing `<PathMap>` and `<SuppressNETCoreSdkPreviewMessage>` properties for context.